### PR TITLE
Fix bug: Incorrect attributes passed to asserts in deposit() method

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## What was the problem?
The issue was an incorrect usage of properties from the Global object in few assertions in the deposit method.

## How did you solve the problem?
**Global.current_application_address** instead of **Global.current_application_id** in the second assert
**Global.current_application_id** instead of **Global.current_application_address** in the fourth assert (op.app_opted_in())

![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/5107647/a5e964e7-210a-48b6-a22e-9476c47cbf65)
