### PR TITLE
Fix type mismatches in personal_vault contract

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
What was the problem?

This PR addresses the following specific errors:
Line 26: Unsupported operand comparison. This has been corrected to ensure proper type compatibility.
Line 30: Incorrect argument type passed to app_opted_in. The argument now conforms to the expected type.

How did you solve the problem?

Line 26: The correct way to compare ptxn.receiver with a value that has the same type as Global.current_application_address.
Line 30: The app_opted_in function checks whether a specific account has opted into your smart contract application and pass Global.current_application_id.


Screenshot of your terminal showing the result of running the deploy script.

![Screenshot 2567-04-02 at 23 00 17](https://github.com/algorand-coding-challenges/python-challenge-1/assets/3756229/096bef99-5d9c-4e0f-9c3c-c0136ed77631)
