### PR TITLE
fix deposit method bugs

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
**1. What was the problem?**

As part of the deposit method validation, we are attempting to assert that the payment transaction receiver address is the same as the smart contract's address. However, since the assertion is comparing the payment transaction address to the smart contract application ID, an exception is raised because you can't compare an object of type `Account` to another object of type `Application` respectively.

The second exception occurs when we call another assert validation to confirm that the transaction sender opted in successfully. In this case, the opt in function raises an error since an invalid parameter is used in the form of the smart contract address.

**2. How did you solve the problem?**

In the first case above, the exception is fixed by using the smart contract address i.e. `Global.current_application_address` instead of the application ID.

The second exception is finally resolved by passing the smart contract application ID i.e. `Global.current_application_id` as the second parameter of the `op.app_opted_in` method instead of the smart contract address.

**3. Screenshot of your terminal showing the result of running the deploy script.**

![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/40172652/ea42f85e-b9ff-416e-a1d3-1f838ea03ba3)
