### PR TITLE
Fix assertions in PersonalVault.deposit

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
**What was the problem?**

Two assertions in `PersonalVault.deposit` were wrong.

**How did you solve the problem?**

Corrected the two assertions:
* `assert (ptxn.receiver == Global.current_application_address), "Deposit receiver must be the contract address"`
* `assert op.app_opted_in(Txn.sender, Global.current_application_id), "Deposit sender must opt-in to the app first."` 

**Screenshot of your terminal showing the result of running the deploy script.**

![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/1091843/10cf009b-1e4b-4622-97ac-79d62f739bda)
