### PR TITLE
* python challenge 1 fixed

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
**What was the bug?**
Within the deposit method, there are 2 bugs related to the assert tests: 
- The first bug relates to the second assert attempt, to test that the payment transaction receiver address is the same as the smart contract app ID (`Global.current_application_id`).
- The second bug relates to the fourth assert attempt, to test that the transaction sender is opted into the smart contract using the smart contract address (`Global.current_application_address`).

**How did you fix the bug?**
- The first bug was resolved by using  `Global.current_application_address` instead of the smart contract app ID.
- The second bug was resolved by using `Global.current_application_id` as the second parameter of the `op.app_opted_in` method

**Console Screenshot:**
![Screenshot 2024-04-02 200531](https://github.com/algorand-coding-challenges/python-challenge-1/assets/96948324/ca136518-baa2-4ab7-bb91-93f44e5cde81)

