### PR TITLE
fix: mismatch

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
**What was the problem?**
Two assertions in PersonalVault.deposit were wrong. 
In the deposit() method , ptxn.receiver wasn't correctly set and the second argument of app_opted_in() function wasn't correctly set.

**How did you solve the problem?**
Changed the Global.current_application_id to Global.current_application_address in the second assert, and vice-versa in fourth assert in the method op.app_opted_in.

**Screenshot of your terminal showing the result of running the deploy script:**
![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/100454472/acbc67e1-642b-4aeb-9f65-959bf1694af5)
