### PR TITLE
Python Algokit challenge #1 complete!

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The problem is two parts. The first is on line 26, the `ptxn.receiver == Global.current_application_id` when it's clearly commented that the "Deposit receiver must be the contract address" yet the `current_application_id` was being passed instead.  
And on line 30, the second parameter of assert `op.app_opted_in()` function needed to be the application ID and instead it was being passed the `current_application_address`.  
> "iskysun96 really dropped the ball here :-D lol"

**How did you fix the bug?**

2. Updated `ptxn.receiver` to be `Global.current_application_address` 
And the second parameter of assert `op.app_opted_in()` becomes `Global.current_application_id`

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/57732382/8dac7d9a-af8a-4bff-93fe-44251fee2666)
