### PR TITLE
bugfix

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

the receiver was compared with the application ID and not the address, and the app opted in was checking the application address and not the ID

<!-- Provide a clear and concise description of the bug. -->

by changing current_application_id to current_application_address in one instance and current_application_address to current_application_id in the other.

<!-- Explain the steps you took to fix the bug. -->

<img width="1016" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/87063425/7aafaa35-a13c-4a18-99ca-15ac405b1658">

<!-- Attach a screenshot of your console showing the result specified in the README. -->
