### PR TITLE
Solution

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

There were two mistakes in the `deposit()` method:

1) The receiver of the deposit was incorrectly compared with the application ID instead of the application address.
2) In the check for whether the sender has already opted into the application, the application address was used instead of its ID.

**How did you fix the bug?**

Exchanged comparison of the receiver with the application address, and application address with the application ID in opt-in check.

**Console Screenshot:**
![202404_solution_py_1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/115161770/61fe482c-d07a-464e-9034-2db9467af5da)

