### PR TITLE
Fixed the bugs!

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Two bugs were present in the `deposit` method:
1. The assert on L25 was checking a transaction receiver against the current application id instead of its address.
2. The asset on L29 was checking that the transaction sender was opted into the current application address instead of its id.

**How did you fix the bug?**

Coincidentally, the two uses of `Global.current_application_id` and `Global.current_application_address` can be switched to resolve both bugs.

**Console Screenshot:**

![Bug fix](https://github.com/algorand-coding-challenges/python-challenge-1/assets/20627143/57be47ed-3f8f-4f13-8249-974d3fb67ca6)
