### PR TITLE
Solution to Challenge 1

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
There were two bugs in the assert statements in the `deposit` method.
App ID and app address were used in the wrong places.

**How did you fix the bug?**

The first assert statement:
`ptxn.receiver == Global.current_application_id`
had to be changed to:
`ptxn.receiver == Global.current_application_address`

and the second:

`op.app_opted_in(Txn.sender, Global.current_application_address)`
had to be changed to:
`op.app_opted_in(Txn.sender, Global.current_application_id)`

**Console Screenshot:**

<img width="643" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/152750039/74a63237-1c1a-4cc8-99f8-e63d0acf23b7">

<img width="771" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/152750039/d73fdc3f-9e24-4958-9f6f-54c94ab70e6c">
