### PR TITLE
Update contract.py

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

1) `ptxn.receiver` is being compared with `Global.current_application_id`, where `ptxn.receiver` is an address and `Global.current_application_id` is an integer.

2) Use `Global.current_application_address` as an argument where an application ID is expected.

**How did you fix the bug?**

1) Corrected comparison between addresses in the deposit method from `ptxn.receiver == Global.current_application_id`  to `ptxn.receiver == Global.current_application_address`

2) Corrected argument type for `app_opted_in`

**Console Screenshot:**

![algorandpythonchallenge1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/113017737/b406b02c-fe7e-4ff6-b7d5-25f23d9e6496)

