### PR TITLE
	modified:   projects/challenge/smart_contracts/personal_vault/contra…

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
…ct.py

## Algorand Coding Challenge Submission

**What was the bug?**

The issue was in the smart contract assertions. When checking the vault receiver, it was using the application's ID instead of its address. And when checking if the sender had opted in to the contract, it was trying to use the contract address instead of the application ID.

**How did you fix the bug?**

To resolve the issue, I had to change the assertion for checking receiver to match the Global.current_application_address. And I also had to change the assertion for the opt-in function to have Global.current_application_id as the second argument.

**Console Screenshot:**

![terminal](https://github.com/algorand-coding-challenges/python-challenge-1/assets/138631273/6b3540ae-b0a6-42a9-8c0d-90640cc4a203)
