### PR TITLE
Fix deposit receiver comparison in PersonalVault contract

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The bug is you pass wrong value to compare in 2 assertion

![Screenshot 2024-04-04 085930](https://github.com/algorand-coding-challenges/python-challenge-1/assets/8998403/27485159-dacd-4454-8ebb-72a158d64602)

![Screenshot 2024-04-04 085934](https://github.com/algorand-coding-challenges/python-challenge-1/assets/8998403/aed293ff-a359-44ff-ba1c-c4db3c14d9e3)

**How did you fix the bug?**

It should be
![Screenshot 2024-04-04 090140](https://github.com/algorand-coding-challenges/python-challenge-1/assets/8998403/d656aba4-5954-41e1-a324-cbe54f64345f)

```
assert (
            ptxn.receiver == Global.current_application_address
        ), "Deposit receiver must be the contract address"
```
and
```
 assert op.app_opted_in(
            Txn.sender, Global.current_application_id
        ), "Deposit sender must opt-in to the app first."
```

**Console Screenshot:**

![Screenshot 2024-04-04 085608](https://github.com/algorand-coding-challenges/python-challenge-1/assets/8998403/aa2b82c3-b6df-42ba-9dc4-df4e81c8a5c1)

