### PR TITLE
fix: use address when comparing to receiver, and application when checking app_opted_in

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION


## Algorand Coding Challenge Submission

**What was the bug?**

Wrong use of address and application. 

**How did you fix the bug?**

Updated comparison to check against address and use application when calling app_opted_in. 

**Console Screenshot:**

(Note: intentionally cut off images to preserve anonymity)

<img width="738" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/157974735/cab784d7-25e1-4553-ad08-72f760408ade">

<img width="591" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/157974735/a691fdae-16ba-4c83-b7b3-dbb6051198c4">
