### PR TITLE
Fix deposit method

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the problem?**

Two asserts were failing in the `contract.py::deposit()` method.
- The first assert expected an Account address to be found for the deposit receiver, but instead it got an application id.
- The second assert checked that the sender is indeed opted in to the correct application id, but found an Account address in its place.

**How did you fix the bug?**

Simply swapped the two incorrect arguments:
- The first assert received the `Global.current_application_address` instead of `Global.current_application_id`
- while the second assert received the `Global.current_application_id` instead of `Global.current_application_address`

**Console Screenshot:**

<img width="950" alt="image" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/162426140/f7c7b194-99c1-425c-a6a0-3335e44c6fb9">

**Other - Dependency version upgrades**
When first tried to setup the project dependencies via `algokit bootstrap all`, both the `algokit` and `python` versions were below the required:

```bash
You are using AlgoKit version 1.12.2, however version 2.0.2 is available. Please update using the tool used to install AlgoKit.
.env.localnet already exists; skipping bootstrap of .env.localnet
.env already exists; skipping bootstrap of .env
.env.testnet already exists; skipping bootstrap of .env.testnet
Installing Python dependencies and setting up Python virtual environment via Poetry
poetry: The currently activated Python version 3.10.12 is not supported by the project (^3.12).
poetry: Trying to find and use a compatible version.
poetry: 
poetry: Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.
```

Upgrade algokit:
```bash
pipx upgrade algokit
upgraded package algokit from 1.12.2 to 2.0.2
```

Download Python 3.12 (will not work with Python 3.13, due to cffi (1.16.0) wheel issues):
```bash
sudo add-apt-repository ppa:deadsnakes/ppa
sudo apt update
sudo apt install python3.12
```

Set new python version to be poetry's default via: 
```bash
ls /usr/bin/python*
poetry env use /usr/bin/python3.12
poetry env info
```

After these steps the `algokit project bootstap all` worked, and could build the project artifacts. However, to be able to deploy the smart contract, the ``algokit_sandbox`` Docker container and images needed to be recreated with the new algokit version.