### PR TITLE
Update contract.py

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

incorrectly using Algorand's Global.current_application_id as if it were an address in the context of a transaction, specifically in the deposit method's receiver validation and in the opt-in check condition. 

Deposit Receiver Validation Bug: The code mistakenly checked if the payment transaction's receiver (ptxn.receiver) matched the Global.current_application_id. However, ptxn.receiver expects an Algorand address, not an application ID. Application IDs and addresses serve fundamentally different purposes on the blockchain; one identifies a smart contract application, while the other specifies transaction endpoints.
Opt-in Check Condition Bug: The original code incorrectly used Global.current_application_address in an opt-in verification function (op.app_opted_in) where it should have used Global.current_application_id. The function is designed to check if a user account has opted into an application, requiring an application ID as the identifier, not an address.

**How did you fix the bug?**

In the deposit method, I corrected the receiver validation to check against the contract's address (Global.current_application_address) instead of the application ID. This ensures deposits are sent to the correct address.
For checking if a user has opted into the contract, the corrected code uses the application ID (Global.current_application_id), not the address. This validation ensures that only users who have opted in can deposit or withdraw.

**Console Screenshot:**

See attached: 
<img width="1457" alt="Screenshot 2024-04-04 at 9 24 15 AM" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/30813409/681a8e04-aca4-4eac-babf-6eb512151519">

