### PR TITLE
solved the bug!

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
The bug is in the assert statements -
1. in the first assert function --- "Deposit receiver must be the contract address"
 here instead of address , id is passed
```ptxn.receiver == Global.current_application_id```

2. in second assert function 
 here the bug is it uses address instead of id
```assert op.app_opted_in( Txn.sender, Global.current_application_address)```

![problem python coding challenge](https://github.com/algorand-coding-challenges/python-challenge-1/assets/107026627/001cbaf8-d7bf-451a-be3c-35d9d9e6b7a8)


<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->

We just need two swap both attributes and it will work fine! just pass ``Global.current_application_address`` to first assert function and then for second one pass ``Global.current_application_id``

**Console Screenshot:**
![python coding challenge 1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/107026627/9beecd84-1d7d-445a-a49b-36fdb1681b4d)


<!-- Attach a screenshot of your console showing the result specified in the README. -->
