### PR TITLE
Bug fixed

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The txn receiver was being compared to the app ID and the validation of the opt-in needed the app ID and was receiving the address  

**How did you fix the bug?**

`ptxn.receiver == Global.current_application_id` changed to `ptxn.receiver == Global.current_application_address`
and 
`op.app_opted_in(Txn.sender, Global.current_application_address)` changed to `op.app_opted_in(Txn.sender, Global.current_application_id)`

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/14205644/33197edb-0255-443e-849e-2b77c644e6ec)
![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/14205644/6d4c9222-26a1-4d16-9b6d-611ab11cc68e)


<!-- Attach a screenshot of your console showing the result specified in the README. -->
