### PR TITLE
Solution

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The console showed 2 errors in the contract:
```
smart_contracts/personal_vault/contract.py:26 error: Unsupported operand types for == ("Account" and "Application")  [operator]
ptxn.receiver == Global.current_application_id

smart_contracts/personal_vault/contract.py:30 error: Argument 2 to "app_opted_in" has incompatible type "Account"; expected "Application | UInt64 | int"  [arg-type]
Txn.sender, Global.current_application_address
```
Turns out there was a type mismatch in a comparison within the deposit function.

**How did you fix the bug?**

Swapping Global.current_application_id and Global.current_application_address solved the issue. 

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/63990513/a9ce291e-bdc5-4600-9b64-ed514888e496)
