### PR TITLE
Fix smart contract errors

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

There were two bugs in the assert statements of the deposit method because the app ID and address were used incorrectly.

**How did you fix the bug?**

ptxn.receiver == Global.current_application_id 
was changed to 
ptxn.receiver == Global.current_application_address. 

op.app_opted_in(Txn.sender, Global.current_application_address) 
was changed to 
op.app_opted_in(Txn.sender, Global.current_application_id).

**Console Screenshot:**

![Screenshot 2024-04-04 at 8 16 54 PM](https://github.com/algorand-coding-challenges/python-challenge-1/assets/16024719/5f1b64f6-fe1b-400a-a099-83f6346ebfbd)
