### PR TITLE
challenge is done

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
There was mistake at ptx.receiver=global.current.application _address
and in op.app_opted  Txn.sender, Global.current_application_id

**How did you fix the bug?**
 assert ptxn.amount > 0, "Deposit amount must be greater than 0"
        assert (
            ptxn.receiver == Global.current_application_id
        ), "Deposit receiver must be the contract address"
        assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
        assert op.app_opted_in(
            Txn.sender, Global.current_application_address
        ), "Deposit sender must opt-in to the app first."


**Console Screenshot:**

![Screenshot 2024-04-05 171829](https://github.com/algorand-coding-challenges/python-challenge-1/assets/137642294/bcd185ab-3093-4b11-b7d7-4595e700fde0)

