### PR TITLE
[Fix] Application address and ID was swapped

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Application ID was used as destination for the payment transaction and application address was used to check if the user has opted in the application.

**How did you fix the bug?**

I used Global.current_application_address as destination for the payment transaction and Global.current_application_id as identifier of the application for optin check.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/162464577/eca42e8a-54b8-488c-b31c-1a22b8e6a207)
