### PR TITLE
Bug Solved

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Assert on Line26 & Line30 are wrong
1. `ptxn.receiver == Global.current_application_id`
2. `Txn.sender, Global.current_application_address`

**How did you fix the bug?**
1. For line26
   `ptxn.receiver == Global.current_application_address`
    Previously it was checking application id but it is for checking address of receiver and contract address was same or not

2. For Line30
   `Txn.sender, Global.current_application_id`
    Previously it was checking contract address but this is for checking the weather sender has opt-in or not for that we need 
    to check application id

<img width="775" alt="Screenshot 2024-04-05 at 8 49 10 PM" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/84325277/5988c98d-4a1f-46f2-bb55-63f8e76794c4">

**Console Screenshot:**
<img width="1370" alt="Screenshot 2024-04-05 at 8 38 00 PM" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/84325277/3fc1962d-8f12-49f5-97cf-595a8c6e6748">

