### PR TITLE
Fix the contract

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The `deposit()` method of the `PersonalVault` contract had incompatible types in assertions on lines 26 and 30.

**How did you fix the bug?**

Comparing the transaction receiver with `Global.current_application_address` and changing `op.app_opted_in()` argument to `Global.current_application_id` fixed the errors.

**Console Screenshot:**

![python-challenge-1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/114208957/a4f34efa-9251-4af1-9f79-dac1c5425ba2)
