### PR TITLE
bug fixed

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
there are two errors in the assert:

1. ptxn.receiver == Global.current_application_id
2. Txn.sender, Global.current_application_address

**How did you fix the bug?**
1. change with: ptxn.receiver == Global.current_application_address
    the comparison must be made with the contract address and not with the ID
2. change with: Txn.sender, Global.current_application_id
    in this case you need the contract id and not the address

**Console Screenshot:**
![Schermata 2024-04-05 alle 21 01 09](https://github.com/algorand-coding-challenges/python-challenge-1/assets/76650075/966f9178-1cf9-41c6-a84c-3bf220980ccc)
