### PR TITLE
Fixed Global values when asserting receiver and app_opted_in

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The wrong Global values were used when asserting the ptxn.receiver and op.app_opted_in.

**How did you fix the bug?**

- current_application_id changed to **current_application_address** when asserting the ptxn.receiver
- current_application_address changed to **current_application_id** when asserting the app_opted_in

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/38738148/348e3dbf-90a6-4095-af5a-10cbd8d61531)

