### PR TITLE
Solved: Algorand Python Challenge 1

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

<!-- Provide a clear and concise description of the bug. -->
The bug was about two errors in two different assert statements, respectively on line 26 and 30.
On line 26, the code was asserting that the receiver address of the Payment Transaction was equal to the newly created application ID (from Global), in this case the error was the comparison between two different objects, so the "==" operator was not supported in this case.
The second error on line 30 was caused by an assertion that aimed to verify that the transaction sender had opted-in in the smart contract, but for that in the code there was a call to the function "algopy.op.app_opted_in" with the second argument "Global.current_application_address", for the code to work it needs the Application ID, not the address that was passed.

**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->
To fix the bug, I replaced the application ID with the application address on line 26 to make possible the "==" operator between two objects of the same type for which this comparison is possible (ptxn.receiver == Global.current_application_address).
While on line 30, to fix the bug I replaced the second argument passed to the function "algopy.op.app_opted_in", because this function needs tha Application ID to verify (assert) that an Account/address (the sender in this case) has opted-in in the smart contract (Application).

**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->
![image](https://github.com/algorand-coding-challenges/python-challenge-1/assets/55320885/4ef8e820-6529-4e3e-92f2-12746b69f6ee)
