### PR TITLE
[python-challenge-1] Fix Bug Wrong

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,13 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            # ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            # Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The bug is you pass wrong value to compare in 2 assertion
![p1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/90815635/46b08060-28f9-426e-8778-bfbf826fc37f)

**How did you fix the bug?**

 I read the code and took a look to the documentation. Change 2 assert  **ptxn.receiver** and **Txn.sender**
![p4](https://github.com/algorand-coding-challenges/python-challenge-1/assets/90815635/66a4974f-8315-4623-a022-3677ed982414)

**Console Screenshot:**
![p2](https://github.com/algorand-coding-challenges/python-challenge-1/assets/90815635/1ea5943b-e436-43b9-93dc-3e30f3e1258e)
![p3](https://github.com/algorand-coding-challenges/python-challenge-1/assets/90815635/2c63c392-3b8b-46ad-85f2-beee10ee895f)


