### PR TITLE
FEAT: fixed the python challenge

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The error came from here, the Global.current_application_id was mixed with the Global.current_application address
`assert (
            ptxn.receiver == Global.current_application_id
        ), "Deposit receiver must be the contract address"
        assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
        assert op.app_opted_in(
            Txn.sender, Global.current_application_address
        ), "Deposit sender must opt-in to the app first."`

**How did you fix the bug?**
Setting the transaction receiver to the Global.current_application_address and the placing the op.app_opted_in should have the Global.current_application_id.
`assert (
            ptxn.receiver == Global.current_application_address
        ), "Deposit receiver must be the contract address"
        assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
        assert op.app_opted_in(
            Txn.sender, Global.current_application_id
        ), "Deposit sender must opt-in to the app first."`


**Console Screenshot:**
<img width="1256" alt="Screenshot 2024-04-10 at 13 38 19" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/43073157/bbc96b0f-441a-479a-afed-d1692c27e0d4">

