### PR TITLE
Update contract.py

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

<!-- Provide a clear and concise description of the bug. -->

-> Given code after debugging give an error at
     1. """ ptxn.receiver == Global.current_application_id """
and
     2. """ Txn.sender, Global.current_application_address """
because, above both are comparing the Address type and Application type
=>In (1) expression, ptxn.receiver returns the Address type but Global.current_application_id returns the application type comparing both gives an error.

=> In (2) expression, op.app_opted_in method is comparing the Txn.sender(returns Application type) and Global.current_application_address ( reuturns Address type) here, we are comparing different types of data so we get an error.


**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->

=>To solve (1) we need to use the current_application_address (reuturns address type) method in Global class { Global.current_application_address }
=>To solve (2) we need to use the current_application_id method(reuturns Application type) in Global class { Global.current_application_id }

**Console Screenshot:**
![algorand python chanllenge 1 output](https://github.com/algorand-coding-challenges/python-challenge-1/assets/127660977/89c567b6-0eed-4114-8c4b-a6ce838b66ab)


<!-- Attach a screenshot of your console showing the result specified in the README. -->
