### PR TITLE
Update contract.py

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Incorrect Global params being used when asserting receiver address and app id within opt in function

**How did you fix the bug?**

Run code using VS Code python debugger. Noticed errors on lines 26 & 30. Received errors stating "Unsupported operand types" and "incompatible type". I noticed that the receiver property was expecting type Account and the opt in function was expecting type  Application. Reviewed algopy api documentation and found correct Global properties to assign 

**Console Screenshot:**
<img width="1036" alt="Screenshot 2024-04-14 at 6 57 41 PM" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/77548895/ca4285cb-b260-4f39-b472-0db53231e58f">


