### PR TITLE
Update contract.py

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
> Given code after debugging give an error at !. 
1."* ptxn.receiver == Global.current_application_id "** 
and
2."'*' Ton.sender, Global.current _application address **
because, above both are comparing the Address type and Application type
=> exp(1), ptxn.receiver returns the Address type but Global.current_application_id returns the application type comparing both gives an error.
=> exp(2), op.app_opted_in method is comparing the Ten.sender(returns Application type) and slobal.current_application_address ( reuturns Address type) here, we are comparing different types of data so we get an error.
<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**
-> To solve (1) we need to use the current_application_address (returns address type) method in Global class slobal.current application_address }
=> To solve (2) we need to use the current application_ id method (reutums Application type) in Global class {
slobal.current application_id }

<!-- Explain the steps you took to fix the bug. -->

**Console Screenshot:**
![python challenge-1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/166385419/4817030f-990d-4eed-9372-2314c178bbf4)
<!-- Attach a screenshot of your console showing the result specified in the README. -->
