### PR TITLE
Update contract.py

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
 After debugging, we saw that the code is given with a bug at
Line 26 - """ptxn.reciever == Global.current_application_id"""
              and
Line 30 - """Txn.sender , Global.current_application_address"""
here,we notice that the above both are comparing the address type and application type then 
=>ptxn.reciever returns the Address Type but Global.current_Application_Id (returns the application type) and by comparing both,gives an error as well as in ln(2) expression also
=> op.app_opted_in method is comparing the Txn.sender( returns Application type) and
Global.current_application_address(returns Address Type) .By comparing two different types of data gives an error.

**How did you fix the bug?**
=> To fix bug (1), we need to usee the current_application_address(returns Address Type)  method in Global class{
Global.current_application_address }
 To fix bug (1), we need to usee the current_application_id(returns Application Type)  method in Global class{
Global.current_application_id}


**Console Screenshot:**

![pc1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/124434849/9024d9c2-327b-47a7-8542-86a2bb0e59ba)
