### PR TITLE
Update contract.py

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
given code after debugging  at
"""ptnx,recevier == Global.current_application_id"""
and
"""Txn.sender,Global.current.application_address"""
beacause, above both are comparing the adreess type and application type
in(1) expression,ptnx.recevier returns the adreess type but Global.current_application type 
in (2) expression.op.app_opted_in method is comparing the Txn.sender(returns Adress type)here,we are comparing different types data so we get an error


<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**
to slove(1) we need to use the current_application_address(returns adresss type )method in gobal class {
gobal.current_application_adress
}
to slove (2) we need to use the current_application_id method(returns application type)in gobal class {
gobal.current_application_id }

<!-- Explain the steps you took to fix the bug. -->

**Console Screenshot:**
![Screenshot 2024-04-20 155037](https://github.com/algorand-coding-challenges/python-challenge-1/assets/134705239/e359068c-1fe8-4103-957e-9da68644121d)


<!-- Attach a screenshot of your console showing the result specified in the README. -->
