### PR TITLE
Finish Challenge 1 Algorand

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

When we debugged, we have an error with "ptxn.receiver == Global.current_application_id" --> ptxn.receiver is of type Account and Global.current_application_id is of type Application. 
We can not compare these two directly. 

Same problem with the second error "op.app_opted_in(Txn.sender, Global.current_application_address)" --> The second argument to app_opted_in should be an application ID, not an address. 

**How did you fix the bug?**

In order to check if the receiver of the payment transaction (ptxn.receiver) is the same as the address of the current application, we should compare ptxn.receiver with Global.current_application_address not Global.current_application_id.

Then, we use Global.current_application_id instead of Global.current_application_address to check if an account has opted into the application.

**Console Screenshot:**

![Algorand ScreenShot Challenge1 - nathan6292](https://github.com/algorand-coding-challenges/python-challenge-1/assets/117782435/0715cb28-f874-4665-bbe9-6a831181db40)
