### PR TITLE
First Challenge Solved

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
…t.py

## Algorand Coding Challenge Submission

mixed id and address

<!-- Provide a clear and concise description of the bug. -->

Line 26: Receiver must be the contract address, but code says `current_application_id` 
Line 30: Checking if txn.sender is opted in to the application, but code says `current_application_address`

**How did you fix the bug?**

Line 25: changed from `id` to `address`
Line 30: changed `address` to `id`

**Console Screenshot:**
![chmpallenge1](https://github.com/algorand-coding-challenges/python-challenge-1/assets/109489750/f643d6f7-484b-45f5-a6fc-5cfab609a26a)
