### PR TITLE
bug fixed!

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

2 bugs
 - the assert to check the receiver address incorrectly compared receiver with the application id
 - the opt_in function incorrectly used the application address instead of the application id



**How did you fix the bug?**

swapped application id for application address in the assert
swapped application address for application id in the opt_in function

<img width="733" alt="Screenshot 2024-04-24 at 20 20 08" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/93330009/a6865b0a-39c8-4479-8957-845739be3a36">

