### PR TITLE
Challenge-1

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

the receiver attribute of an object referenced by ptx.n is equal to the current application ID stored in Global.current_application_id,
and in op.app_opted in Global.current_application_address

**How did you fix the bug?**
 assert ptxn.amount > 0, "Deposit amount must be greater than 0"
assert (
ptxn.receiver == Global.current_application_address
), "Deposit receiver must be the contract address"
assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
assert op.app_opted_in(
Txn.sender,Global.current_application_id
), "Deposit sender must opt-in to the app first."

**Console Screenshot:**

![Screenshot 2024-05-04 195231](https://github.com/algorand-coding-challenges/python-challenge-1/assets/168916170/c8b08b70-71c8-48b0-b305-6a94aa20ad7c)

