### PR TITLE
challenge solvedd

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount
@@ -47,3 +47,4 @@ class PersonalVault(ARC4Contract):
         ).submit()
 
         return userBalance
+


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

What was the bug?

->given code after debugging gives an error at
1."""ptxn.receiver==Global.current_application_id"""
2."""txn.sender, global.current_application_address"""
the above are coparing the adress type and application type
->in one expression, ptxn.reciver returns the address type global.current_application_id returns the application type comparing both gives an error.

->in second expression ,op.app_opted_in method is comparing the txt.sender(return application type )


**How did you fix the bug?**

to solve one we need to use the current_application_address(returns addres type)method in Global class{
Global.current_application_address}
->to solve secondone we need to use the current_application_address(return address type)method in Global class{
Global.current_application_id}
![Screenshot (10)](https://github.com/algorand-coding-challenges/python-challenge-1/assets/157580927/81004a0d-ac39-4420-ad74-661de9198cf7)


**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->
