### PR TITLE
solved

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount
@@ -47,3 +47,4 @@ class PersonalVault(ARC4Contract):
         ).submit()
 
         return userBalance
+


### PR DESCRIPTION
## Algorand Coding Challenge Submission

What was the bug?
-> Given code after debugging give an error at

*** ptxn.receiver == Global.current application_id ***
and
***Txn.sender, Global.current application address ***
because, above both are comparing the Address type and Application type
=>In (1) expression, ptxn.receiver returns the Address type but Global.current application id returns the application type comparing both gives an error.
=> In (2) expression, op.app_opted_ in method is comparing the T×n.sender(returns Application type) and Global.current_application_address ( returns Address type) here, we are comparing different types of data so we get an error.
How did you fix the bug?
=> To solve (1) we need to use the current_ application_address (returns address type) method in Global class
Global.current application_address }
=> To solve (2) we need to use the current_application id method(returns Application type) in Global class {
Global.current_application_id }

**Console Screenshot:**
<img width="1470" alt="Screenshot 2024-05-06 at 10 00 11 AM" src="https://github.com/algorand-coding-challenges/python-challenge-1/assets/116417608/48ab6c30-0b27-4eb5-af03-8be1c434058b">

<!-- Attach a screenshot of your console showing the result specified in the README. -->
