### PR TITLE
Fix type mismatches in PersonalVault smart contract for Python Challenge 1

### DIFF
--- a/projects/challenge/smart_contracts/personal_vault/contract.py
+++ b/projects/challenge/smart_contracts/personal_vault/contract.py
@@ -23,11 +23,11 @@ class PersonalVault(ARC4Contract):
     def deposit(self, ptxn: gtxn.PaymentTransaction) -> UInt64:
         assert ptxn.amount > 0, "Deposit amount must be greater than 0"
         assert (
-            ptxn.receiver == Global.current_application_id
+            ptxn.receiver == Global.current_application_address
         ), "Deposit receiver must be the contract address"
         assert ptxn.sender == Txn.sender, "Deposit sender must be the caller"
         assert op.app_opted_in(
-            Txn.sender, Global.current_application_address
+            Txn.sender, Global.current_application_id
         ), "Deposit sender must opt-in to the app first."
 
         self.balance[Txn.sender] += ptxn.amount


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The bug occurred in the `PersonalVault` smart contract's `deposit` method:

1. The `ptxn.receiver` was incorrectly compared to `Global.current_application_id` instead of `Global.current_application_address`, leading to a type mismatch.
2. The `op.app_opted_in` function was called with an incorrect type for the second argument, resulting in an error due to an incompatible type comparison.

**How did you fix the bug?**

1. Updated the comparison in the `deposit` method to use `Global.current_application_address` instead of `Global.current_application_id`, ensuring that deposits are correctly sent to the smart contract's account.
2. Corrected the second argument passed to `op.app_opted_in` by using `Global.current_application_id`, aligning it with the expected types.

**Console Screenshot:**

![python-challenge-1-jeff-stein-5-9-24](https://github.com/algorand-coding-challenges/python-challenge-1/assets/105945985/d8419c20-febc-468f-820f-b6a6b508e9d6)